### PR TITLE
node: make child_count return 0 on `end` nodes

### DIFF
--- a/ext/tree_sitter/node.c
+++ b/ext/tree_sitter/node.c
@@ -1,4 +1,5 @@
 #include "tree_sitter.h"
+#include "tree_sitter/api.h"
 
 extern VALUE mTreeSitter;
 
@@ -88,7 +89,13 @@ static VALUE node_field_name_for_child(VALUE self, VALUE idx) {
 }
 
 static VALUE node_child_count(VALUE self) {
-  return UINT2NUM(ts_node_child_count(SELF));
+  TSNode node = SELF;
+  const char *type = ts_node_type(node);
+  if (strcmp(type, "end") == 0) {
+    return UINT2NUM(0);
+  } else {
+    return UINT2NUM(ts_node_child_count(SELF));
+  }
 }
 
 static VALUE node_named_child(VALUE self, VALUE idx) {

--- a/ext/tree_sitter/tree_sitter.h
+++ b/ext/tree_sitter/tree_sitter.h
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <ruby.h>
 #include <stdio.h>
+#include <string.h>
 #include <tree_sitter/api.h>
 
 static inline VALUE safe_str(const char *str) {


### PR DESCRIPTION
Still waiting for a confirmation [from tree-sitter devs](https://github.com/tree-sitter/tree-sitter/discussions/1814) on whether this is a bug in their code or in the parser we're using and which produces child_count > 0 for `end` nodes, or maybe simply we're misusing the library.

Until then, and until someone complains, this will be default behavior.